### PR TITLE
Ac anim

### DIFF
--- a/framework/include/model_types.hpp
+++ b/framework/include/model_types.hpp
@@ -18,6 +18,12 @@ namespace gvk
 		return glm::quat(aAssimpQuat.w, aAssimpQuat.x, aAssimpQuat.y, aAssimpQuat.z);
 	}
 
+	/** Convert from a GLM quaternion to an ASSIMP quaternion */
+	static aiQuaternion to_aiQuaternion(const glm::quat& aGlmQuat)
+	{
+		return aiQuaternion(aGlmQuat.w, aGlmQuat.x, aGlmQuat.y, aGlmQuat.z);
+	}
+
 	/** Convert from an ASSIMP mat4 to a GLM mat4 */
 	static glm::mat4 to_mat4(const aiMatrix4x4& aAssimpMat)
 	{

--- a/framework/src/animation.cpp
+++ b/framework/src/animation.cpp
@@ -1,5 +1,5 @@
 #include <gvk.hpp>
-#include <glm/gtx/quaternion.hpp> // ac temp
+#include <glm/gtx/quaternion.hpp>
 
 namespace gvk
 {

--- a/framework/src/animation.cpp
+++ b/framework/src/animation.cpp
@@ -43,7 +43,6 @@ namespace gvk
 				auto scaling = glm::lerp(anode.mScalingKeys[spos1].mValue, anode.mScalingKeys[spos2].mValue, sf);
 
 				localTransform = matrix_from_transforms(translation, rotation, scaling);
-
 			}
 
 			// Calculate the node's global transform, using its local transform and the transforms of its parents:

--- a/framework/src/animation.cpp
+++ b/framework/src/animation.cpp
@@ -31,24 +31,8 @@ namespace gvk
 					std::tie(rpos1, rpos2) = find_positions_in_keys(anode.mRotationKeys, timeInTicks);
 				}
 				auto rf = get_interpolation_factor(anode.mRotationKeys[rpos1], anode.mRotationKeys[rpos2], timeInTicks);
-
-#if 0
-				// original implementation (glm linear interpolation) - jerky
-				auto rotation = glm::lerp(anode.mRotationKeys[rpos1].mValue, anode.mRotationKeys[rpos2].mValue, rf);
-#elif 0
-				// glm spherical interpolation via mix - still jerky
-				auto rotation = glm::mix(anode.mRotationKeys[rpos1].mValue, anode.mRotationKeys[rpos2].mValue, rf);
-#elif 1
-				// using Assimp's interpolation - this fixes the jerks completely!
-				aiQuaternion q;
-				aiQuaternion::Interpolate(q, to_aiQuaternion(anode.mRotationKeys[rpos1].mValue), to_aiQuaternion(anode.mRotationKeys[rpos2].mValue), rf);
-				glm::quat rotation = to_quat(q);
-				// Note: not sure if normalizing the quaternion afterwards is actually necessary / improves anything. Looks good even without normalizing.
-#elif 0
-				// glm spherical interpolation via slerp - this looks good too, even without post-normalization
-				auto rotation = glm::slerp(anode.mRotationKeys[rpos1].mValue, anode.mRotationKeys[rpos2].mValue, rf);
-#endif
-				rotation=glm::normalize(rotation); // by itself, this fixes some of the jerks with glm lerp/mix interpolations, but not all of them
+				auto rotation = glm::slerp(anode.mRotationKeys[rpos1].mValue, anode.mRotationKeys[rpos2].mValue, rf);	// use slerp, not lerp or mix (those lead to jerks)
+				rotation = glm::normalize(rotation); // normalize the resulting quaternion, just to be on the safe side
 
 				// Scaling:
 				size_t spos1 = tpos1, spos2 = tpos2;

--- a/framework/src/model.cpp
+++ b/framework/src/model.cpp
@@ -451,6 +451,9 @@ namespace gvk
 			
 			// We've got bone weights. Proceed as planned.
 			for (decltype(n) i = 0; i < n; ++i) {
+				// sort the current vertex' <bone id, weight> pairs descending by weight (so we can take the four most important ones)
+				std::sort(vTempWeightsPerVertex[i].begin(), vTempWeightsPerVertex[i].end(), [](std::tuple<uint32_t, float> a, std::tuple<uint32_t, float> b) { return std::get<float>(a) > std::get<float>(b); });
+
 				auto& weights = result.emplace_back(0.0f, 0.0f, 0.0f, 0.0f);
 				for (size_t j = 0; j < std::min(size_t{4}, vTempWeightsPerVertex[i].size()); ++j) {
 					weights[j] = std::get<float>(vTempWeightsPerVertex[i][j]);
@@ -486,6 +489,9 @@ namespace gvk
 			
 			// We've got bone weights. Proceed as planned.
 			for (decltype(n) i = 0; i < n; ++i) {
+				// sort the current vertex' <bone id, weight> pairs descending by weight (so we can take the four most important ones)
+				std::sort(vTempWeightsPerVertex[i].begin(), vTempWeightsPerVertex[i].end(), [](std::tuple<uint32_t, float> a, std::tuple<uint32_t, float> b) { return std::get<float>(a) > std::get<float>(b); });
+
 				auto& weights = result.emplace_back(0u, 0u, 0u, 0u);
 				for (size_t j = 0; j < std::min(size_t{4}, vTempWeightsPerVertex[i].size()); ++j) {
 					weights[j] = std::get<uint32_t>(vTempWeightsPerVertex[i][j]);

--- a/framework/src/model.cpp
+++ b/framework/src/model.cpp
@@ -837,7 +837,7 @@ namespace gvk
 				}
 				for (unsigned int i = 0; i < bChannel->mNumRotationKeys; ++i) {
 					anode.mRotationKeys.emplace_back(rotation_key{
-						bChannel->mRotationKeys[i].mTime, to_quat(bChannel->mRotationKeys[i].mValue)
+						bChannel->mRotationKeys[i].mTime, glm::normalize(to_quat(bChannel->mRotationKeys[i].mValue))	// normalize the quaternion, just to be on the safe side
 					});
 				}
 				for (unsigned int i = 0; i < bChannel->mNumScalingKeys; ++i) {

--- a/framework/src/model.cpp
+++ b/framework/src/model.cpp
@@ -455,8 +455,9 @@ namespace gvk
 				std::sort(vTempWeightsPerVertex[i].begin(), vTempWeightsPerVertex[i].end(), [](std::tuple<uint32_t, float> a, std::tuple<uint32_t, float> b) { return std::get<float>(a) > std::get<float>(b); });
 
 				auto& weights = result.emplace_back(0.0f, 0.0f, 0.0f, 0.0f);
-				for (size_t j = 0; j < std::min(size_t{4}, vTempWeightsPerVertex[i].size()); ++j) {
-					weights[static_cast<int>(j)] = std::get<float>(vTempWeightsPerVertex[i][j]);
+				const auto numWeights = std::min(int{ 4 }, static_cast<int>(vTempWeightsPerVertex[i].size()));
+				for (int j = 0; j < numWeights; ++j) {
+					weights[j] = std::get<float>(vTempWeightsPerVertex[i][j]);
 				}
 			}
 		}
@@ -493,8 +494,9 @@ namespace gvk
 				std::sort(vTempWeightsPerVertex[i].begin(), vTempWeightsPerVertex[i].end(), [](std::tuple<uint32_t, float> a, std::tuple<uint32_t, float> b) { return std::get<float>(a) > std::get<float>(b); });
 
 				auto& weights = result.emplace_back(0u, 0u, 0u, 0u);
-				for (size_t j = 0; j < std::min(size_t{4}, vTempWeightsPerVertex[i].size()); ++j) {
-					weights[static_cast<int>(j)] = std::get<uint32_t>(vTempWeightsPerVertex[i][j]);
+				const auto numWeights = std::min(int{ 4 }, static_cast<int>(vTempWeightsPerVertex[i].size()));
+				for (int j = 0; j < numWeights; ++j) {
+					weights[j] = std::get<uint32_t>(vTempWeightsPerVertex[i][j]);
 				}
 			}
 		}

--- a/framework/src/model.cpp
+++ b/framework/src/model.cpp
@@ -456,7 +456,7 @@ namespace gvk
 
 				auto& weights = result.emplace_back(0.0f, 0.0f, 0.0f, 0.0f);
 				for (size_t j = 0; j < std::min(size_t{4}, vTempWeightsPerVertex[i].size()); ++j) {
-					weights[j] = std::get<float>(vTempWeightsPerVertex[i][j]);
+					weights[static_cast<int>(j)] = std::get<float>(vTempWeightsPerVertex[i][j]);
 				}
 			}
 		}
@@ -494,7 +494,7 @@ namespace gvk
 
 				auto& weights = result.emplace_back(0u, 0u, 0u, 0u);
 				for (size_t j = 0; j < std::min(size_t{4}, vTempWeightsPerVertex[i].size()); ++j) {
-					weights[j] = std::get<uint32_t>(vTempWeightsPerVertex[i][j]);
+					weights[static_cast<int>(j)] = std::get<uint32_t>(vTempWeightsPerVertex[i][j]);
 				}
 			}
 		}
@@ -674,7 +674,7 @@ namespace gvk
 	{
 		std::vector<gvk::camera> result;
 		result.reserve(mScene->mNumCameras);
-		for (int i = 0; i < mScene->mNumCameras; ++i) {
+		for (unsigned int i = 0; i < mScene->mNumCameras; ++i) {
 			aiCamera* aiCam = mScene->mCameras[i];
 			auto cgbCam = gvk::camera();
 			cgbCam.set_aspect_ratio(aiCam->mAspect);


### PR DESCRIPTION
Fixed occasional glitches/jerks in animations

Replaced the original `glm::lerp` method to interpolate rotation quaternions by Assimp's `aiQuaternion::Interpolate`.
This works smoothly now; alternatively `glm::slerp` works fine too.

Left various interpolation methods `#ifdef`'ed out in the source for now, to facilitate comparison in quality and performance.
These can be removed later.