### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/external/universal/include/stb_image.h
+++ b/external/universal/include/stb_image.h
@@ -3183,6 +3183,13 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
       if (z->img_comp[i].v > v_max) v_max = z->img_comp[i].v;
    }
 
+   // check that plane subsampling factors are integer ratios; our resamplers can't deal with fractional ratios
+   // and I've never seen a non-corrupted JPEG file actually use them
+   for (i=0; i < s->img_n; ++i) {
+      if (h_max % z->img_comp[i].h != 0) return stbi__err("bad H","Corrupt JPEG");
+      if (v_max % z->img_comp[i].v != 0) return stbi__err("bad V","Corrupt JPEG");
+   }
+
    // compute interleaved mcu info
    z->img_h_max = h_max;
    z->img_v_max = v_max;


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in external/universal/include/stb_image.h which was cloned from nothings/stb but did not receive the security patch applied. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2021-28021.

### Proposed Fix
Apply the same patch as the one in nothings/stb to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2021-28021
https://github.com/nothings/stb/commit/5ba0baaa269b3fd681828e0e3b3ac0f1472eaf40